### PR TITLE
Rename `friends.all` to `friends.stream` in docs

### DIFF
--- a/tmpl/docs/social/query-the-social-graph.md
+++ b/tmpl/docs/social/query-the-social-graph.md
@@ -1,15 +1,15 @@
 ## Fetch the social graph
 
-You can see who follows whom by calling the `friends.all` method.
+You can see who follows whom by calling the `friends.stream` method.
 It will provide an object of `{ userId => [followedIds] }`.
 
 ```js
-sbot.friends.all(function (err, graph) {
+sbot.friends.stream(function (err, graph) {
   // ...
 })
 ```
 ```bash
-sbot friends.all
+sbot friends.stream
 ```
 
 Example output:


### PR DESCRIPTION
`friends.all` doesn't seem to exist anywhere, but `friends.stream` provides the described functionality.