### PR TITLE
use working link for ferment project

### DIFF
--- a/tmpl/apps/index.html.js
+++ b/tmpl/apps/index.html.js
@@ -9,7 +9,7 @@ module.exports = () => page({
     { id: 'patchbay', title: 'Patchbay', desc: 'An alternative Secure Scuttlebutt client interface', url: 'https://github.com/ssbc/patchbay' },
     { id: 'manyverse', title: 'Manyverse', desc: 'Beta Android client', url: 'https://www.manyver.se' },
     { id: 'patchfoo', title: 'Patchfoo', desc: 'Plain SSB web UI. Uses HTML forms instead of client-side JS.', url: 'https://git.scuttlebot.io/%25YAg1hicat%2B2GELjE2QJzDwlAWcx0ML%2B1sXEdsWwvdt8%3D.sha256' },
-    { id: 'ferment', title: 'Ferment', desc: 'Peer-to-peer audio publishing and streaming.', url: 'http://ferment.audio' },
+    { id: 'ferment', title: 'Ferment', desc: 'Peer-to-peer audio publishing and streaming.', url: 'https://github.com/fermentation/ferment' },
     { id: 'ssb-cli-dashboard', title: 'CLI Dashboard', desc: 'Browse the database state.', url: 'https://github.com/ssbc/ssb-cli-dashboard' },
     { id: 'ssb-simple-whois', title: 'CLI Whois', desc: 'Very simple petname->pubkey lookup.', url: 'https://github.com/ssbc/ssb-simple-whois' },
     { id: 'ssb-client-cli', title: 'ssb-client-cli', desc: 'Command Line interface to do basic things with SSB', url: 'https://github.com/qypea/ssb-client-cli' },


### PR DESCRIPTION
The original link for ferment project ( http://ferment.audio ) hits a default host provider page. The new link is to the github repo.